### PR TITLE
Allow user to select methods to ignore.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "cookie": "0.1.2",
     "cookie-signature": "1.0.4",
-    "csrf": "~2.0.1"
+    "csrf": "~2.0.1",
+    "extend": "~1.3.0"
   },
   "devDependencies": {
     "body-parser": "~1.5.2",

--- a/test/test.js
+++ b/test/test.js
@@ -183,6 +183,22 @@ describe('csurf', function () {
     .expect(500, /cookieParser.*secret/, done)
   });
 
+  it('should check GET when explicitly restricted', function(done) {
+    var server = createServer({ignoreMethod: {GET: false}});
+
+    request(server)
+    .get('/')
+    .expect(403, done);
+  });
+
+  it('should not check POST when explicitly allowed', function(done) {
+    var server = createServer({ignoreMethod: {POST: true}});
+
+    request(server)
+    .post('/')
+    .expect(200, done);
+  });
+
   describe('req.csrfToken()', function () {
     it('should return same token for each call', function (done) {
       var app = connect()


### PR DESCRIPTION
Can be useful to add `GET` csrf protection on a router, or otherwise disable checking for a given verb.
