### PR TITLE
Check for _CSRF GET parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,10 @@ module.exports = function csurf(options) {
       secret = tokens.secretSync()
       setsecret(req, res, secret, options.cookie)
     }
+    
+    if (req.query._csrf) {
++      delete ignoreMethod['GET'];
++    }
 
     // verify the incoming token
     if (!ignoreMethod[req.method]) {


### PR DESCRIPTION
If req.query._csrf the GET method will be deleted from the ignored methods so you can build ?_csrf= to check for token. This could be useful for csrf with links. 

I use this and I wanted to share with you.
