### PR TITLE
Splits token generation and validation

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -197,7 +197,7 @@ describe('csurf', function () {
     app.use(csurf())
 
     request(app)
-    .get('/')
+    .post('/')
     .expect(500, /misconfigured csrf/, done)
   });
 
@@ -208,7 +208,7 @@ describe('csurf', function () {
     app.use(csurf({ cookie: { signed: true } }))
 
     request(app)
-    .get('/')
+    .post('/')
     .expect(500, /cookieParser.*secret/, done)
   });
 


### PR DESCRIPTION
I'm currently using this branch one a personal project and it seems to work fine. Tests are (mostly) passing, check the following for more infos.

It splits the token generation and validation into two different steps, so one can return the csrf token without having to actually validate it. Cf #10. 

**Additions**
  - `csurf.generator()` is a middleware adding the following to the request object :
      - `csrfToken()` returns the current session token (as before)
      - `checkCsrf()` returns a boolean : true if the csrf token is correctly set (**new**)

  - `csurf.validator()` is a middleware automatically calling the `checkCsrf()` method from the request object, and returning a 403 error if the token does not match. Note that this middleware depends on `csurf.generator`.

**Changes**
  - One of the test expected every requests to crash when there was `!cookie && !req.session` (bad configuration settings), even when the request method was supposed to be ignored. I fixed it. The un-fix is pretty simple, so tell me if you want to revert it, but I think it should be mostly safe, since it's a bit impossible to run a website with a bad configuration anyway.

- I've added my name to the credit list since it doesn't really fit the short patch pattern. Tell me if I should not !

**WIP**
  - One test is failing (*csurf should error without cookieParser secret and signed cookie storage*), because validating a csrf does not cause one to be created. I think it is correct too, but your call.
