### PR TITLE
Allow to manually verify CSRF tokens for ignored methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,9 +95,16 @@ module.exports = function csurf(options) {
       setsecret(req, res, secret, cookie)
     }
 
-    // verify the incoming token
     if (!ignoreMethod[req.method]) {
+      // verify the incoming token
       verifytoken(req, tokens, secret, value(req))
+    } else {
+      // allow to manually verify later
+      req.csrfVerify = verifytoken.bind(null, req, tokens, secret, value(req))
+      req.csrfCheck = function(){
+        try { return req.csrfVerify(), true }
+        catch (err) { return false }
+      }
     }
 
     next()
@@ -238,4 +245,7 @@ function verifytoken(req, tokens, secret, val) {
       code: 'EBADCSRFTOKEN'
     });
   }
+  // mark req as valid and don't check again
+  req.csrfVerify = function(){ }
+  req.csrfCheck = function(){ return true }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -313,6 +313,36 @@ describe('csurf', function () {
       .expect(500, /misconfigured csrf/, done)
     })
   })
+
+  describe('manual validation', function() {
+    var app
+    before(function(){
+      app = connect()
+      app.use(session({ keys: ['a', 'b'] }))
+      app.use(csurf())
+      app.use('/verify', function (req, res) {
+        req.csrfVerify()
+        res.end()
+      })
+      app.use('/check', function (req, res) {
+        res.end('result:'+req.csrfCheck())
+      })
+    })
+    describe('req.csrfVerify()', function() {
+      it('requires a valid token to be passed', function(done) {
+        request(app)
+        .get('/verify')
+        .expect(403, done)
+      })
+    })
+    describe('req.csrfCheck()', function() {
+      it('checks whether a valid token was passed', function(done) {
+        request(app)
+        .get('/check')
+        .expect('result:false', done)
+      })
+    })
+  })
 });
 
 function cookies(req) {


### PR DESCRIPTION
Useful for blocking specific GET endpoints from being accessed without a CSRF token. In my specific use-case, its for blocking sensitive JSON-returning endpoints to avoid cross-domain JSON hijacking.

Without exposing this functionality from inside of csurf, replicating the behavior can get quite messy.