### PR TITLE
Adding in Support for Flexible Session Keys

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
-unreleased
-==========
+1.7.0 / 2015-02-15
+==================
 
   * Accept `CSRF-Token` and `XSRF-Token` request headers
   * Default `cookie.path` to `'/'`, if using cookies

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ following keys:
   - any other [res.cookie](http://expressjs.com/4x/api.html#res.cookie)
     option can be set.
 
+##### sessionKey
+
+If `cookie` is set to `false`, which means a session will be used for storing
+the token secret -- this setting determines *which* session key should be used.
+
+This allows for you to store CSRF tokens in a particular session store.
+
+This defaults to `'session'` (*eg: req.session*).  If you change it to another
+string, like `'testSession'`, for instance, then the `req.testSession` session
+will be used to store CSRF tokens.
+
 ##### ignoreMethods
 
 An array of the methods for which CSRF token checking will disabled.

--- a/index.js
+++ b/index.js
@@ -34,6 +34,9 @@ module.exports = function csurf(options) {
   // get cookie options
   var cookie = getCookieOptions(options.cookie)
 
+  // get session options
+  var sessionKey = options.sessionKey || 'session'
+
   // get value getter
   var value = options.value || defaultValue
 

--- a/index.js
+++ b/index.js
@@ -56,13 +56,13 @@ module.exports = function csurf(options) {
   var ignoreMethod = getIgnoredMethods(ignoreMethods)
 
   return function csrf(req, res, next) {
-    var secret = getsecret(req, cookie)
+    var secret = getsecret(req, sessionKey, cookie)
     var token
 
     // lazy-load token getter
     req.csrfToken = function csrfToken() {
       var sec = !cookie
-        ? getsecret(req, cookie)
+        ? getsecret(req, sessionKey, cookie)
         : secret
 
       // use cached token if secret has not changed
@@ -172,11 +172,12 @@ function getIgnoredMethods(methods) {
  * Get the token secret from the request.
  *
  * @param {IncomingMessage} req
+ * @param {String} sessionKey
  * @param {Object} [cookie]
  * @api private
  */
 
-function getsecret(req, cookie) {
+function getsecret(req, sessionKey, cookie) {
   var secret
 
   if (cookie) {
@@ -186,9 +187,9 @@ function getsecret(req, cookie) {
       : 'cookies'
 
     secret = req[bag][cookie.key]
-  } else if (req.session) {
+  } else if (req[sessionKey]) {
     // get secret from session
-    secret = req.session.csrfSecret
+    secret = req[sessionKey].csrfSecret
   } else {
     throw new Error('misconfigured csrf')
   }

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ module.exports = function csurf(options) {
       // generate & set new secret
       if (sec === undefined) {
         sec = tokens.secretSync()
-        setsecret(req, res, sec, cookie)
+        setsecret(req, res, sessionKey, sec, cookie)
       }
 
       // update changed secret
@@ -88,7 +88,7 @@ module.exports = function csurf(options) {
     // generate & set secret
     if (!secret) {
       secret = tokens.secretSync()
-      setsecret(req, res, secret, cookie)
+      setsecret(req, res, sessionKey, secret, cookie)
     }
 
     // verify the incoming token
@@ -223,12 +223,13 @@ function setcookie(res, name, val, options) {
  *
  * @param {IncomingMessage} req
  * @param {OutgoingMessage} res
+ * @param {string} sessionKey
  * @param {string} val
  * @param {Object} [cookie]
  * @api private
  */
 
-function setsecret(req, res, val, cookie) {
+function setsecret(req, res, sessionKey, val, cookie) {
   if (cookie) {
     // set secret on cookie
     if (cookie.signed) {
@@ -242,9 +243,9 @@ function setsecret(req, res, val, cookie) {
     }
 
     setcookie(res, cookie.key, val, cookie);
-  } else if (req.session) {
+  } else if (req[sessionKey]) {
     // set secret on session
-    req.session.csrfSecret = val
+    req[sessionKey].csrfSecret = val
   } else {
     /* istanbul ignore next: should never actually run */
     throw new Error('misconfigured csrf')

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csurf",
   "description": "CSRF token middleware",
-  "version": "1.6.6",
+  "version": "1.7.0",
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "body-parser": "~1.12.0",
+    "client-sessions": "^0.7.0",
     "connect": "3",
     "cookie-parser": "~1.3.4",
     "cookie-session": "~1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "body-parser": "~1.12.0",
-    "client-sessions": "^0.7.0",
+    "client-sessions": "~0.7.0",
     "connect": "3",
     "cookie-parser": "~1.3.4",
     "cookie-session": "~1.1.0",


### PR DESCRIPTION
This commit should fix #66.

Basically, I added a new option `sessionKey`, which allows the developer to specify the name of the session key used.

I added in README docs, a working implementation, and tests which support this.

Happy to make changes if needed.