### PR TITLE
Option to pass errors the connect way.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ locations, in order:
   - `req.headers['x-csrf-token']` - the `X-CSRF-Token` HTTP request header.
   - `req.headers['x-xsrf-token']` - the `X-XSRF-Token` HTTP request header.
 
+##### throwErrors
+
+Throw errors instead of using the more common `next(err)` in connect-style. 
+Although the default is `true` to ensure backwards compatibility, you'll
+likely want `false` instead.
+
 ## Example
 
 ### Simple express example

--- a/test/test.js
+++ b/test/test.js
@@ -277,6 +277,25 @@ describe('csurf', function () {
     })
   })
 
+  it('should use connect conventions with throwErrors set to false', function(done) {
+    var app = connect()
+    app.use(function(req, res, next) {
+      csurf({ throwErrors: false })(req, res, function(err){
+        if (err === undefined) {
+          res.end('It worked!');
+        } else {
+          // Error got passed as expected.
+          res.statusCode = 403;
+          res.end('error');
+        }
+      });
+    });
+
+    request(app)
+        .post('/')
+        .expect(403, done);
+  });
+
   describe('with "sessionKey" option', function () {
     it('should use the specified sessionKey', function (done) {
       var app = connect()


### PR DESCRIPTION
Use `next(err)` instead of throw err when the developer prefers this behavior.
Fixes #78 .

To enable this behavior, set `options.throwErrors` to `false`.