### PR TITLE
Added error for no active session

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,14 +101,14 @@ function csurf (options) {
       return token
     }
 
-    var submitted = value(req);
-    
+    var submitted = value(req)
+
     // generate & set secret
     if (!secret) {
       if (!ignoreMethod[req.method] && submitted) {
         return next(createError(403, 'csrf token submitted but there is no active session', {
           code: 'ECSRFNOSESSION'
-        }));
+        }))
       }
       secret = tokens.secretSync()
       setSecret(req, res, sessionKey, secret, cookie)

--- a/index.js
+++ b/index.js
@@ -101,14 +101,21 @@ function csurf (options) {
       return token
     }
 
+    var submitted = value(req);
+    
     // generate & set secret
     if (!secret) {
+      if (!ignoreMethod[req.method] && submitted) {
+        return next(createError(403, 'csrf token submitted but there is no active session', {
+          code: 'ECSRFNOSESSION'
+        }));
+      }
       secret = tokens.secretSync()
       setSecret(req, res, sessionKey, secret, cookie)
     }
 
     // verify the incoming token
-    if (!ignoreMethod[req.method] && !tokens.verify(secret, value(req))) {
+    if (!ignoreMethod[req.method] && !tokens.verify(secret, submitted)) {
       return next(createError(403, 'invalid csrf token', {
         code: 'EBADCSRFTOKEN'
       }))

--- a/index.js
+++ b/index.js
@@ -101,13 +101,17 @@ function csurf (options) {
       return token
     }
 
-    var submitted = value(req)
+    var submitted
+
+    if (!ignoreMethod[req.method]) {
+      submitted = value(req)
+    }
 
     // generate & set secret
     if (!secret) {
-      if (!ignoreMethod[req.method] && submitted) {
-        return next(createError(403, 'csrf token submitted but there is no active session', {
-          code: 'ECSRFNOSESSION'
+      if (submitted) {
+        return next(createError(403, 'no established csrf secret', {
+          code: 'ENOECSRFTOKEN'
         }))
       }
       secret = tokens.secretSync()

--- a/test/test.js
+++ b/test/test.js
@@ -202,6 +202,25 @@ describe('csurf', function () {
     })
   })
 
+  it('should fail with no token', function (done) {
+    var app = connect()
+    app.use(session({ keys: ['a', 'b'] }))
+
+    app.use(function (req, res, next) {
+      req.query = url.parse(req.url, true).query
+      next()
+    })
+    app.use(bodyParser.urlencoded({extended: false}))
+    app.use(csurf())
+
+    var server = http.createServer(app)
+
+    request(server)
+    .post('/')
+    .set('X-CSRF-Token', 'sadsadsadsfdsf')
+    .expect(403, /no established csrf secret/, done)
+  })
+
   it('should provide error code on invalid token error', function (done) {
     var app = connect()
     app.use(session({ keys: ['a', 'b'] }))


### PR DESCRIPTION
Added error check for no active session. Generate early error and return in that situation. Following talk on #126:

> Because if a token is incoming and a new secret is also being generated, there is certainly no way that the token will match the secret, so even trying to match is likely a waste and I figure providing a different error in that case will be better than the single error.

@dougwilson

Edit: this is WIP and haven't built+tested it locally. Some extra tests would be needed which I'll try to make later on when I can clone+build+test locally.