### PR TITLE
add req.csrfCookie

### DIFF
--- a/index.js
+++ b/index.js
@@ -265,6 +265,7 @@ function setCookie (res, name, val, options) {
  */
 
 function setSecret (req, res, sessionKey, val, cookie) {
+  req.csrfCookie = val
   if (cookie) {
     // set secret on cookie
     var value = val


### PR DESCRIPTION
When there is no cookie, req.csrfCookie is added to handle only the server side of the specific function without using a cookie