### PR TITLE
Csurf-expire patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ following keys:
   - `key` - the name of the cookie to use to store the token secret
     (defaults to `'_csrf'`).
   - `path` - the path of the cookie (defaults to `'/'`).
+  - `maxAge` - the maximum age the cookie can be before it expires in seconds. Setting this parameter will cause a 403 response if any cookie and csfr token is sent beyond the maxAge window.
   - any other [res.cookie](http://expressjs.com/4x/api.html#res.cookie)
     option can be set.
 
@@ -116,7 +117,7 @@ var bodyParser = require('body-parser')
 var express = require('express')
 
 // setup route middlewares
-var csrfProtection = csrf({ cookie: true })
+var csrfProtection = csrf({ cookie: { maxAge: 60 * 60 * 8 } })
 var parseForm = bodyParser.urlencoded({ extended: false })
 
 // create express app
@@ -220,7 +221,7 @@ app.use('/api', api)
 // now add csrf and other middlewares, after the "/api" was mounted
 app.use(bodyParser.urlencoded({ extended: false }))
 app.use(cookieParser())
-app.use(csrf({ cookie: true }))
+app.use(csrf({ cookie: { maxAge: 60 * 60 * 8 } }))
 
 app.get('/form', function (req, res) {
   // pass the csrfToken to the view

--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ module.exports = csurf
 
 function csurf (options) {
   var opts = options || {}
-  
 
   // get cookie options
   var cookie = getCookieOptions(opts.cookie)
@@ -71,6 +70,7 @@ function csurf (options) {
     if (!verifyConfiguration(req, sessionKey, cookie)) {
       return next(new Error('misconfigured csrf'))
     }
+
     // get the secret from the request
     var secret = getSecret(req, sessionKey, cookie)
     var token
@@ -89,7 +89,8 @@ function csurf (options) {
       // generate & set new secret
       if (sec === undefined) {
         sec = tokens.secretSync()
-        setSecret(req, res, sessionKey, test, cookie)
+        sec = setExpiry(sec, cookie)
+        setSecret(req, res, sessionKey, sec, cookie)
       }
 
       // update changed secret
@@ -104,16 +105,16 @@ function csurf (options) {
     // generate & set secret
     if (!secret) {
       secret = tokens.secretSync()
+      secret = setExpiry(secret, cookie)
       setSecret(req, res, sessionKey, secret, cookie)
     }
 
     // verify the incoming token
-    if (!ignoreMethod[req.method] && (!tokens.verify(secret, value(req)) || !verifyExpiry(secret,cookie))) {
+    if (!ignoreMethod[req.method] && (!tokens.verify(secret, value(req)) || !verifyExpiry(secret, cookie))) {
       return next(createError(403, 'invalid csrf token', {
         code: 'EBADCSRFTOKEN'
       }))
     }
-
 
     next()
   }
@@ -234,6 +235,25 @@ function getSecretBag (req, sessionKey, cookie) {
 }
 
 /**
+ * Set an expiry time on the cookie.
+ *
+ * @param {string} val
+ * @param {Object} [options]
+ * @api private
+ */
+
+function setExpiry (val, options) {
+  var secret = val
+  if (options) {
+    if (options.maxAge) {
+      var time = ((new Date().getTime() + (options.maxAge * 1000)).toString(21))
+      secret += ('-' + time)
+    }
+  }
+  return secret
+}
+
+/**
  * Set a cookie on the HTTP response.
  *
  * @param {OutgoingMessage} res
@@ -244,12 +264,7 @@ function getSecretBag (req, sessionKey, cookie) {
  */
 
 function setCookie (res, name, val, options) {
-  if (options.maxAge){
-    var time = ((new Date().getTime()+(options.maxAge*1000)).toString(21))
-    val += ("-"+time)
-  }
   var data = Cookie.serialize(name, val, options)
-
   var prev = res.getHeader('set-cookie') || []
   var header = Array.isArray(prev) ? prev.concat(data)
     : Array.isArray(data) ? [prev].concat(data)
@@ -298,19 +313,19 @@ function setSecret (req, res, sessionKey, val, cookie) {
  * Verify the cookie/token has not expired.
  * @private
  */
-function verifyExpiry (secret,cookie) {
-  if(cookie.maxAge){
-    var index = secret.lastIndexOf('-')
-    if (index === -1) 
-      return false
-    var time = secret.substr(index+1,secret.length-index)
-    time = parseInt(time, 21)
-    return (new Date().getTime()) < time
+function verifyExpiry (secret, cookie) {
+  if (cookie) {
+    if (cookie.maxAge) {
+      var index = secret.lastIndexOf('-')
+      if (index === -1) { return false }
+      var time = secret.substr(index + 1, secret.length - index)
+      time = parseInt(time, 21)
+      return (new Date().getTime()) < time
+    }
   }
-  
   return true
-} 
- 
+}
+
 /**
  * Verify the configuration against the request.
  * @private


### PR DESCRIPTION
Added in functionality that allows for the read in of the "max age" option for a cookie (if being created with cookies not sessions). If the cookie is expired, then we will reject the token. Puts up a minor defence against storing cookie and tokens and replaying them days later.

Rather than store cookies in a database, we can simply apend the expiry time to the cookie and obfuscate the value so its not completely obvious what it represents. We can then generate the XSRF token like normal. When checking the cookie(secret) we decode the time and compare it to the currect time to determine if it has expired.

Was thinking that rather than automatically enabling this feature if a user sets the MaxAge property on a cookie, it may be prudent to add a seperate options flag. I am open to any suggestions on how to improve this functionality.

Thank you for your time and consideration