### PR TITLE
Dependency version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": "expressjs/csurf",
   "dependencies": {
-    "cookie": "0.3.1",
+    "cookie": "0.4.0",
     "cookie-signature": "1.0.6",
     "csrf": "3.1.0",
     "http-errors": "~1.7.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "csurf",
   "description": "CSRF token middleware",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "author": "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>"


### PR DESCRIPTION
The newest version of the dependency "cookie" has a sameSite option of "none" which will be required in future versions of Chrome in conjunction with the secure flag to send the cookie to the backend.