### PR TITLE
Support sameSite none option

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,8 @@
 unreleased
 ==========
 
+  * deps: cookie@0.4.0
+    - Add `SameSite=None` support
   * deps: http-errors@~1.7.3
     - deps: inherits@2.0.4
 

--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ following keys:
     (defaults to session length).
   - `httpOnly` - flags the cookie to be accessible only by the web server
     (defaults to `false`).
-  - `sameSite` - sets the same site policy for the cookie (defaults to none).
-  - `domain` - sets the domain the cookie is valid on (defaults to current
+  - `sameSite` - sets the same site policy for the cookie(defaults to
+    `false`). This can be set to `'strict'`, `'lax'`, `'none'`, or `true`
+    (which maps to `'strict'`).
+  - `domain` - sets the domain the cookie is valid on(defaults to current
     domain).
 
 ##### ignoreMethods

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": "expressjs/csurf",
   "dependencies": {
-    "cookie": "0.3.1",
+    "cookie": "0.4.0",
     "cookie-signature": "1.0.6",
     "csrf": "3.1.0",
     "http-errors": "~1.7.3"


### PR DESCRIPTION
In February of the 2019 it's planning to release chrome browser v80, where sameSite flags would be enabled by default. In order to have possibility set sameSite option to none value, we have to update cookie package to version v0.4.0