### PR TITLE
Add option to regenerate the secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ locations, in order:
   - `req.headers['x-csrf-token']` - the `X-CSRF-Token` HTTP request header.
   - `req.headers['x-xsrf-token']` - the `X-XSRF-Token` HTTP request header.
 
+##### regenSecret
+
+When set to true every call to `req.crsfToken()` will generate a new token
+and a new secret.
+
+Defaults to `false`.
+
 ## Example
 
 ### Simple express example


### PR DESCRIPTION
Previous functionality allowed the same token to be used for the life of
the session. This option will regenerate the secret everytime
req.crsfToken() is called, invalidating the previous secret.

Related issues:
https://github.com/expressjs/csurf/issues/188
https://github.com/expressjs/csurf/issues/120