### PR TITLE
feature: prevent user call `csurf()` repeatedly

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var Cookie = require('cookie')
 var createError = require('http-errors')
 var sign = require('cookie-signature').sign
 var Tokens = require('csrf')
-
+var isInitialized = false
 /**
  * Module exports.
  * @public
@@ -39,6 +39,11 @@ module.exports = csurf
  */
 
 function csurf (options) {
+  if (isInitialized) {
+    throw new Error('csrf() is not allowed called than one time.')
+  }
+  isInitialized = true;
+
   var opts = options || {}
 
   // get cookie options


### PR DESCRIPTION
## Introduction

Recently, I answered a [question](https://stackoverflow.com/questions/64869650/csrf-doesnt-work-on-the-first-post-attempt/64877159#64877159) in the stackoverflow.
The user repeatedly call `csurf` then put it into express middleware.
It result in a error message "invalid csrf token" when user make form post **at first time.**

## Reason

This is a sample code make this happen.   

Reproduced Way: 
1. Open a **new incognito window** (it must be a new window which doesn't have cookie of `localhost:8080`)
2. Go to `http://localhost:8080/settings` 
3. Press the submit button

```javascript
// my server.js
const cookieParser = require('cookie-parser')
const csrf = require('csurf')
const bodyParser = require('body-parser')
const express = require('express')
const app = express()
app.set("view engine", "ejs")
app.use(bodyParser.urlencoded({ extended: false }))
app.use(cookieParser())
// ---> mark1
app.use(csrf({ cookie: true }))
app.use((req, res, next) => {
    res.locals.token = req.csrfToken();
    next();
});

// ---> mark2
const csrfProtection = csrf({ cookie: true })
app.get('/settings', csrfProtection, function (req, res) {
    res.render('send')
})
app.post('/settings', csrfProtection, function (req, res) {
    res.send('data is being processed')
})
app.listen(8080)
```

```html
<!-- my send.ejs -->
<form method="POST" action="/settings">
  <input type="hidden" name="_csrf" value="<%= locals.token %>">
  <button class="btn btn-primary">Submit</button>
</form>
```
We could there are two line called `csurf()` and put it into middleware of express in mark1 and mark2.
In mark1, csurf will generate a `secret1` and `token1` to give ejs template.
But, in mark2, csurf is re-initialized, secret and token1 is changed.
That means csurf will validate next request with new `secret2` and `token2`.

But, it only happen **at the first time validation.**
Subsequently, the request will be validated correctly.

## Solution

I think I could add a flag to decide the csurf is initialized or not.   
It's default is false, it will be changed to true when user call `csurf()`.
Then It will throw error when initialized is already true.

I'm not sure is it a good idea to prevent user from using `csurf()`
Please let me know,  is there any problem will make a new problem?
Thanks!
