### PR TITLE
throw error when the user repeatedly call csurf in same middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,9 +67,9 @@ function csurf (options) {
 
   return function csrf (req, res, next) {
     if (req.isInitialized) {
-      console.warn("[Warning] csurf() is duplicately called with same middleware in the cooke mode, first validation will result in the invalid token.")
+      console.warn('[Warning] csurf() is duplicately called with same middleware in the cooke mode, first validation will result in the invalid token.')
     }
-      
+
     if (!req.isInitialized && cookie) {
       req.isInitialized = true
     }

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function csurf (options) {
 
   return function csrf (req, res, next) {
     if (req.isInitialized) {
-      console.warn("[Warning] csurf() duplicated called with same middleware in the cooke mode")
+      console.warn("[Warning] csurf() is duplicately called with same middleware in the cooke mode, first validation will result in the invalid token.")
     }
       
     if (!req.isInitialized && cookie) {

--- a/index.js
+++ b/index.js
@@ -66,6 +66,14 @@ function csurf (options) {
   var ignoreMethod = getIgnoredMethods(ignoreMethods)
 
   return function csrf (req, res, next) {
+    if (req.isInitialized) {
+      console.warn("[Warning] csurf() duplicated called with same middleware in the cooke mode")
+    }
+      
+    if (!req.isInitialized && cookie) {
+      req.isInitialized = true
+    }
+
     // validate the configuration against request
     if (!verifyConfiguration(req, sessionKey, cookie)) {
       return next(new Error('misconfigured csrf'))

--- a/test/test.js
+++ b/test/test.js
@@ -232,6 +232,20 @@ describe('csurf', function () {
               .expect(200, done)
           })
       })
+
+      it('should return error when call csurf twice in middleware.', function (done) {
+        var app = connect()
+        app.use(cookieParser('keyboard cat'))
+        app.use(csurf({ cookie: true }))
+        app.use(csurf({ cookie: true }))
+        app.use(function (req, res) {
+          res.end(req.csrfToken() || 'none')
+        })
+
+        request(app)
+          .get('/')
+          .expect(500, /csurf\({cookie: true}\) or csurf\({cookie: {}}}\) is repeatedly called with same middleware in the cooke mode, first validation will result in the invalid token/, done)
+      })
     })
 
     describe('when an object', function () {


### PR DESCRIPTION
I think and think over again in [PR-228](https://github.com/expressjs/csurf/pull/228) and [PR-229](https://github.com/expressjs/csurf/pull/229).  
There are maybe few users repeatedly called `csurf({cookie: true})` with same middleware.  
So, I think I just warn this situation for now.
In the future, we maybe could throw error instead of warning.