### PR TITLE
Fix token caching if secret is not changed

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function csurf (options) {
 
   // generate lookup
   var ignoreMethod = getIgnoredMethods(ignoreMethods)
-  
+
   return function csrf (req, res, next) {
     // validate the configuration against request
     if (!verifyConfiguration(req, sessionKey, cookie)) {

--- a/index.js
+++ b/index.js
@@ -52,6 +52,9 @@ function csurf (options) {
 
   // token repo
   var tokens = new Tokens(opts)
+  
+  // cached token
+  var token
 
   // ignored methods
   var ignoreMethods = opts.ignoreMethods === undefined
@@ -64,7 +67,7 @@ function csurf (options) {
 
   // generate lookup
   var ignoreMethod = getIgnoredMethods(ignoreMethods)
-
+  
   return function csrf (req, res, next) {
     // validate the configuration against request
     if (!verifyConfiguration(req, sessionKey, cookie)) {
@@ -73,7 +76,6 @@ function csurf (options) {
 
     // get the secret from the request
     var secret = getSecret(req, sessionKey, cookie)
-    var token
 
     // lazy-load token getter
     req.csrfToken = function csrfToken () {


### PR DESCRIPTION
The middleware invokes on every request, so, the token variable recreated on every request and token is regenerated every time. We need to hold the token outside of the middleware function.