### PR TITLE
Added ignoreRoutes in the opts so that we can ignore specific routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "cookie": "0.4.0",
     "cookie-signature": "1.0.6",
     "csrf": "3.1.0",
-    "http-errors": "~1.7.3"
+    "http-errors": "~1.7.3",
+    "parseurl": "^1.3.3"
   },
   "devDependencies": {
     "body-parser": "1.19.0",

--- a/test/test.js
+++ b/test/test.js
@@ -468,6 +468,30 @@ describe('csurf', function () {
         .expect(500, /misconfigured csrf/, done)
     })
   })
+
+  describe('with "ignoreRoutes" option', function () {
+    it('should work in req.body', function (done) {
+      var server = createServer({ ignoreRoutes: ['/', '/sample/put'] })
+
+      request(server)
+        .get('/')
+        .expect(200, function (err, res) {
+          if (err) return done(err)
+          var token = res.text
+
+          request(server)
+            .post('/sample/post')
+            .set('Cookie', cookies(res))
+            .set('csrf-token', token)
+            .expect(200, function (err, res) {
+              if (err) return done(err)
+              request(server)
+                .put('/sample/put')
+                .expect(403, done)
+            })
+        })
+    })
+  })
 })
 
 function cookie (res, name) {


### PR DESCRIPTION
Added ignoreRoutes in the opts so that we can ignore specific routes, this will be very useful for people using nestjs. Test codes are added to the last.