### PR TITLE
Add support for cookie.secure === 'auto'

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ following keys:
   - `path` - the path of the cookie (defaults to `'/'`).
   - `signed` - indicates if the cookie should be signed (defaults to `false`).
   - `secure` - marks the cookie to be used with HTTPS only (defaults to
-    `false`).
+    `false`). If set to ``'auto'`, HTTPS will be detected via the `x-forwarded-proto`
+    header, similar to [express-session](https://expressjs.com/en/resources/middleware/session.html#cookiesecure).
   - `maxAge` - the number of seconds after which the cookie will expire
     (defaults to session length).
   - `httpOnly` - flags the cookie to be accessible only by the web server


### PR DESCRIPTION
This mirrors support in [express-session](https://expressjs.com/en/resources/middleware/session.html#cookiesecure) where we look
at the value of req.headers['x-forwarded-proto'] to
automatically determine if we should set Secure.

This provides the developer with a safe way of getting
Secure set, without relying on complicated logic to detect
development environments or set up branching middleware
chains.