### PR TITLE
Support for CSRF token patterns as instructed by OWASP.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ unreleased
     - Fix `maxAge` option to reject invalid values
   * deps: http-errors@1.8.0
     - deps: setprototypeof@1.2.0
+  * Allow selection of `csrfTokenPattern`. Support for HMAC based token pattern and encryption based token pattern added. Defaults to double submit cookie pattern.
 
 1.11.0 / 2020-01-18
 ===================

--- a/test/testEncrypted.js
+++ b/test/testEncrypted.js
@@ -1,0 +1,211 @@
+
+process.env.NODE_ENV = 'test'
+
+var connect = require('connect')
+var http = require('http')
+var bodyParser = require('body-parser')
+var querystring = require('querystring')
+var request = require('supertest')
+
+var csurf = require('..')
+
+describe('csurf with Encryption based token pattern', function () {
+  it('should work in req.body', function (done) {
+    var server = createServerWithoutCookieAndSession({
+      csrfTokenPattern: 'encrypted',
+      encryptionKey: '5e91b89e38697ee924ba9b9940217cf654ecdeed4dc0f551a88c3b7f577469f0'
+    })
+
+    request(server)
+      .get('/')
+      .expect(200, function (err, res) {
+        if (err) return done(err)
+        var token = res.text
+
+        request(server)
+          .post('/')
+          .send('_csrf=' + encodeURIComponent(token))
+          .expect(200, done)
+      })
+  })
+})
+
+it('should work in req.query', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'encrypted',
+    encryptionKey: '5e91b89e38697ee924ba9b9940217cf654ecdeed4dc0f551a88c3b7f577469f0'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/?_csrf=' + encodeURIComponent(token))
+        .expect(200, done)
+    })
+})
+
+it('should work in csrf-token header', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'encrypted',
+    encryptionKey: '5e91b89e38697ee924ba9b9940217cf654ecdeed4dc0f551a88c3b7f577469f0'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/')
+        .set('csrf-token', token)
+        .expect(200, done)
+    })
+})
+
+it('should work in xsrf-token header', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'encrypted',
+    encryptionKey: '5e91b89e38697ee924ba9b9940217cf654ecdeed4dc0f551a88c3b7f577469f0'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/')
+        .set('xsrf-token', token)
+        .expect(200, done)
+    })
+})
+
+it('should work in x-csrf-token header', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'encrypted',
+    encryptionKey: '5e91b89e38697ee924ba9b9940217cf654ecdeed4dc0f551a88c3b7f577469f0'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/')
+        .set('x-csrf-token', token)
+        .expect(200, done)
+    })
+})
+
+it('should work in x-xsrf-token header', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'encrypted',
+    encryptionKey: '5e91b89e38697ee924ba9b9940217cf654ecdeed4dc0f551a88c3b7f577469f0'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/')
+        .set('x-xsrf-token', token)
+        .expect(200, done)
+    })
+})
+
+it('should fail with an invalid token', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'encrypted',
+    encryptionKey: '5e91b89e38697ee924ba9b9940217cf654ecdeed4dc0f551a88c3b7f577469f0'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      request(server)
+        .post('/')
+        .set('X-CSRF-Token', '42')
+        .expect(403, done)
+    })
+})
+
+it('should fail with no token', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'encrypted',
+    encryptionKey: '5e91b89e38697ee924ba9b9940217cf654ecdeed4dc0f551a88c3b7f577469f0'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      request(server)
+        .post('/')
+        .expect(403, done)
+    })
+})
+
+it('should fail with expired token', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'encrypted',
+    encryptionKey: '5e91b89e38697ee924ba9b9940217cf654ecdeed4dc0f551a88c3b7f577469f0',
+    expiry: 0.5
+  })
+
+  // Token expiry is 0.5 seconds and we use it after 1 second.
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      setTimeout(function () {
+        request(server)
+          .post('/')
+          .set('x-xsrf-token', token)
+          .expect(403, done)
+      }, 1000)
+    })
+})
+
+function createServerWithoutCookieAndSession (opts) {
+  var app = connect()
+
+  app.use(function (req, res, next) {
+    var index = req.url.indexOf('?') + 1
+
+    if (index) {
+      req.query = querystring.parse(req.url.substring(index))
+    }
+
+    next()
+  })
+  app.use(bodyParser.urlencoded({ extended: false }))
+
+  app.use(function(req, res, next) {
+    req._csrfUserId = 123
+    req._csrfNonce = 1
+    next()
+  })
+
+  app.use(csurf(opts))
+
+  app.use(function (req, res) {
+    res.end(req.csrfToken() || 'none')
+  })
+
+  return http.createServer(app)
+}

--- a/test/testHmac.js
+++ b/test/testHmac.js
@@ -1,0 +1,212 @@
+
+process.env.NODE_ENV = 'test'
+
+var connect = require('connect')
+var http = require('http')
+var bodyParser = require('body-parser')
+var querystring = require('querystring')
+var request = require('supertest')
+
+var csurf = require('..')
+
+describe('csurf with HMAC based token pattern', function () {
+  it('should work in req.body', function (done) {
+    var server = createServerWithoutCookieAndSession({
+      csrfTokenPattern: 'hmac',
+      hmacSecret: 'e92633a08116905e4f30eefd1'
+    })
+
+    request(server)
+      .get('/')
+      .expect(200, function (err, res) {
+        if (err) return done(err)
+        var token = res.text
+
+        request(server)
+          .post('/')
+          .send('_csrf=' + encodeURIComponent(token))
+          .expect(200, done)
+      })
+  })
+})
+
+it('should work in req.query', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'hmac',
+    hmacSecret: 'e92633a08116905e4f30eefd1'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/?_csrf=' + encodeURIComponent(token))
+        .expect(200, done)
+    })
+})
+
+it('should work in csrf-token header', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'hmac',
+    hmacSecret: 'e92633a08116905e4f30eefd1'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/')
+        .set('csrf-token', token)
+        .expect(200, done)
+    })
+})
+
+it('should work in xsrf-token header', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'hmac',
+    hmacSecret: 'e92633a08116905e4f30eefd1'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/')
+        .set('xsrf-token', token)
+        .expect(200, done)
+    })
+})
+
+it('should work in x-csrf-token header', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'hmac',
+    hmacSecret: 'e92633a08116905e4f30eefd1'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/')
+        .set('x-csrf-token', token)
+        .expect(200, done)
+    })
+})
+
+it('should work in x-xsrf-token header', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'hmac',
+    hmacSecret: 'e92633a08116905e4f30eefd1'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      request(server)
+        .post('/')
+        .set('x-xsrf-token', token)
+        .expect(200, done)
+    })
+})
+
+it('should fail with an invalid token', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'hmac',
+    hmacSecret: 'e92633a08116905e4f30eefd1'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      request(server)
+        .post('/')
+        .set('X-CSRF-Token', '42')
+        .expect(403, done)
+    })
+})
+
+it('should fail with no token', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'hmac',
+    hmacSecret: 'e92633a08116905e4f30eefd1'
+  })
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      request(server)
+        .post('/')
+        .expect(403, done)
+    })
+})
+
+it('should fail with expired token', function (done) {
+  var server = createServerWithoutCookieAndSession({
+    csrfTokenPattern: 'hmac',
+    hmacSecret: 'e92633a08116905e4f30eefd1',
+    expiry: 0.5
+  })
+
+  // Token expiry is 0.5 seconds and we use it after 1 second.
+
+  request(server)
+    .get('/')
+    .expect(200, function (err, res) {
+      if (err) return done(err)
+      var token = res.text
+
+      setTimeout(function () {
+        request(server)
+          .post('/')
+          .set('x-xsrf-token', token)
+          .expect(403, done)
+      }, 1000)
+    })
+})
+
+function createServerWithoutCookieAndSession (opts) {
+  var app = connect()
+
+  app.use(function (req, res, next) {
+    var index = req.url.indexOf('?') + 1
+
+    if (index) {
+      req.query = querystring.parse(req.url.substring(index))
+    }
+
+    next()
+  })
+  app.use(bodyParser.urlencoded({ extended: false }))
+
+  app.use(function(req, res, next) {
+    req._csrfUserId = 123
+    req._csrfNonce = 1
+    req._csrfOperation = 'test'
+    next()
+  })
+
+  app.use(csurf(opts))
+
+  app.use(function (req, res) {
+    res.end(req.csrfToken() || 'none')
+  })
+
+  return http.createServer(app)
+}

--- a/tokenManager/Encrypted.js
+++ b/tokenManager/Encrypted.js
@@ -1,0 +1,86 @@
+const Crypto = require('crypto')
+
+const ALGORITHM = 'aes-256-cbc'
+const IV_LENGTH = 16
+
+/**
+ * Encrypted Token Manager
+ */
+class EncryptedTokenManager {
+  constructor (opts) {
+    this.opts = opts
+
+    this.encryptionKey = this.opts.encryptionKey
+    this.expiry = this.opts.expiry || 60 * 60 // 1 hours default value
+  }
+
+  /**
+   * Verify secret
+   *
+   * @param {string} secret
+   * @param {string} token
+   * @param {IncomingMessage} req
+   * @returns {boolean}
+   */
+  verify (secret, token, req) {
+    if (!token) return false
+
+    const encryptionKey = this.encryptionKey
+    let decrypted
+
+    try {
+      const [iv, encryptedText] = token.split(':').map(part => Buffer.from(part, 'hex'))
+      const decipher = Crypto.createDecipheriv(ALGORITHM, Buffer.from(encryptionKey, 'hex'), iv)
+      decrypted = decipher.update(encryptedText)
+      decrypted = (Buffer.concat([decrypted, decipher.final()])).toString()
+    } catch (e) {
+      return false
+    }
+
+    const tokenParts = decrypted.split(':')
+    if (tokenParts.length !== 3) return false
+
+    const csrfUserId = tokenParts[0]
+    const timestamp = tokenParts[2]
+
+    // Check for token expiry
+    if (Math.floor(Date.now() / 1000) - timestamp > this.expiry) return false
+
+    // Check for csrfUserId
+    return this._sanitize(req._csrfUserId) === csrfUserId
+  }
+
+  /**
+   * Returns token
+   *
+   * @param {String} secret
+   * @param {IncomingMessage} req
+   * @return {String}
+   */
+  create (secret, req) {
+    const encryptionKey = this.encryptionKey
+    const csrfUserId = this._sanitize(req._csrfUserId)
+    const csrfNonce = this._sanitize(req._csrfNonce)
+
+    const text = `${csrfUserId}:${csrfNonce}:${Math.floor(Date.now() / 1000)}`
+    const iv = Crypto.randomBytes(IV_LENGTH)
+    const cipher = Crypto.createCipheriv(ALGORITHM, Buffer.from(encryptionKey, 'hex'), iv)
+    let encrypted = cipher.update(text)
+    encrypted = Buffer.concat([encrypted, cipher.final()])
+
+    return `${iv.toString('hex')}:${encrypted.toString('hex')}`
+  }
+
+  /**
+   * Returns sanitized string
+   *
+   * @param {string} str
+   * @returns {string}
+   * @private
+   */
+  _sanitize (str) {
+    return `${str}`.replace(/\s+/g, '_').replace(/:+/g, '_')
+  }
+}
+
+module.exports = EncryptedTokenManager

--- a/tokenManager/Factory.js
+++ b/tokenManager/Factory.js
@@ -1,0 +1,28 @@
+const DoubleSubmitTokenManager = require('csrf')
+const HmacTokenManager = require('./Hmac')
+const EncryptedTokenManager = require('./Encrypted')
+
+/**
+ * Token Manager Factory class for providing token manager object based on CSRF token pattern
+ */
+class TokenManagerFactory {
+  constructor (opts) {
+    this.opts = opts || {}
+    this.csrfTokenPattern = this.opts.csrfTokenPattern
+  }
+
+  /**
+   * Get token manager object
+   */
+  getTokenManager () {
+    if (this.csrfTokenPattern === 'hmac') {
+      return new HmacTokenManager(this.opts)
+    } else if (this.csrfTokenPattern === 'encrypted') {
+      return new EncryptedTokenManager(this.opts)
+    } else { // If not passed, treat double submit token manager as default.
+      return new DoubleSubmitTokenManager(this.opts)
+    }
+  }
+}
+
+module.exports = TokenManagerFactory

--- a/tokenManager/Hmac.js
+++ b/tokenManager/Hmac.js
@@ -1,0 +1,75 @@
+const Crypto = require('crypto')
+
+/**
+ * HMAC Token Manager
+ */
+class HmacTokenManager {
+  constructor (opts) {
+    this.opts = opts
+
+    this.hmacSecret = this.opts.hmacSecret
+    this.expiry = this.opts.expiry || 60 * 60 // 1 hours default value
+  }
+
+  /**
+   * Verify secret
+   *
+   * @param {string} secret
+   * @param {string} token
+   * @param {IncomingMessage} req
+   * @returns {boolean}
+   */
+  verify (secret, token, req) {
+    if (!token) return false
+
+    const tokenParts = token.split(':')
+    if (tokenParts.length !== 5) return false
+
+    const csrfUserId = tokenParts[0]
+    const csrfNonce = tokenParts[1]
+    const csrfOperation = tokenParts[2]
+    const timestamp = tokenParts[3]
+
+    // Check for token expiry
+    if (Math.floor(Date.now() / 1000) - timestamp > this.expiry) return false
+
+    // Check for csrfUserId
+    if (this._sanitize(req._csrfUserId) !== csrfUserId) return false
+
+    return this.create('dummy', {
+      _csrfUserId: csrfUserId,
+      _csrfNonce: csrfNonce,
+      _csrfOperation: csrfOperation
+    }, timestamp) === token
+  }
+
+  /**
+   * Returns token
+   *
+   * @param {String} secret
+   * @param {IncomingMessage} req
+   * @param {number} timestamp
+   * @return {String}
+   */
+  create (secret, req, timestamp = Math.floor(Date.now() / 1000)) {
+    const csrfUserId = this._sanitize(req._csrfUserId)
+    const csrfNonce = this._sanitize(req._csrfNonce)
+    const csrfOperation = this._sanitize(req._csrfOperation)
+
+    const prefix = `${csrfUserId}:${csrfNonce}:${csrfOperation}:${timestamp}`
+    return prefix + ':' + Crypto.createHmac('sha256', this.hmacSecret).update(prefix).digest('hex')
+  }
+
+  /**
+   * Returns sanitized string
+   *
+   * @param {string} str
+   * @returns {string}
+   * @private
+   */
+  _sanitize (str) {
+    return `${str}`.replace(/\s+/g, '_').replace(/:+/g, '_')
+  }
+}
+
+module.exports = HmacTokenManager


### PR DESCRIPTION
This PR allows selection of `csrfTokenPattern` to be used. Support for HMAC based token pattern and encryption based token pattern added. Defaults to double submit cookie pattern.

Closes #121 

Thanks @dougwilson for helping out in opening up PR creation for non-existing collaborators like me, who would love to contribute in this repository.

Team, please let me know your reviews. I have added new test cases too. Old ones need not be changed as the change is backward compatible.

While going through the [OWASP documentation](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html), I realized that we can have the csrfTokenPattern as an input for a pattern factory that helps select and execute the generation of the token and its validation. Also the factory design will help in pluggable implementation of more patterns in future.